### PR TITLE
fix: Set dotnet version in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '2.1.x'
-          cache: true
 
       - name: Run tests
         run: dotnet test --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,9 @@ on:
   pull_request:
     branches:
       - '*'          # Run the workflow for all pull requests
-  release:
-    types:
-      - published    # Run the workflow when a new GitHub release is published
 
 env:
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
-  NuGetDirectory: ${{ github.workspace }}/nuget
 
 defaults:
   run:
@@ -27,8 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '2.1.x'
+          cache: true
+
       - name: Run tests
         run: dotnet test --configuration Release
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ defaults:
 
 jobs:
   run_test:
+    name: Run tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -27,7 +27,7 @@ jobs:
           path: ./.github/tlabs-actions
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
-      - name: Build and Publish Nuget
+      - name: Build and Publish NuGet
         uses: ./.github/tlabs-actions/publish-nuget-to-nuget_org
         with:
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
To have a good Changelog, we use [`versionize`](https://github.com/versionize/versionize)

Under the hood it uses [Conventional Commmit Specification](https://www.conventionalcommits.org)

The following things MUST be adhered:
1. for `patch` version updates, commit messages subject  MUST have `fix:` prefix
2. for `minor` version updates, commit messages subject MUST have `feat:` prefix
3. for `major` version updates, commit messages subject MUST have `feat:` prefix AND in the body MUST have `BREAKING CHANGE:` prefix.

Examples:
```shell
# patch version bump
git commit -m 'fix: Error while doing something'

# minor version bump
git commit -m 'feat: Awesome new thing'

# major version bump
git commit -m 'feat: Removing something' -m 'BREAKING CHANGE: This removes an important part'
```